### PR TITLE
Fix name clash of .spv compiled shaders

### DIFF
--- a/glsl/rules.bzl
+++ b/glsl/rules.bzl
@@ -51,7 +51,7 @@ def _glsl_shader(ctx):
 
     shader = ctx.file.shader
 
-    spirv_name = shader.basename[:-len(shader.extension)] + "spv"
+    spirv_name = shader.basename[:-len(shader.extension)] + shader.extension + ".spv"
 
     spirv = ctx.actions.declare_file(spirv_name, sibling=shader)
 

--- a/glsl/rules.bzl
+++ b/glsl/rules.bzl
@@ -51,7 +51,7 @@ def _glsl_shader(ctx):
 
     shader = ctx.file.shader
 
-    spirv_name = shader.basename[:-len(shader.extension)] + shader.extension + ".spv"
+    spirv_name = shader.basename + ".spv"
 
     spirv = ctx.actions.declare_file(spirv_name, sibling=shader)
 


### PR DESCRIPTION
**What is this PR about?**
If I have two shaders with the same name:
`my_shader.vert`
`my_shader.frag`
Vulkan rules will attempt to generate two `.spv` files:
`my_shader.spv`
`my_shader.spv`
This would lead to an error, as it would create two files with exactly the same names.

**What's changed?**
Instead, with this PR it would now generate the following files:
`my_shader.vert.spv`
`my_shader.frag.spv`