### PR TITLE
Fix the way GLSLC is invoked from shader rules.

### DIFF
--- a/glsl/BUILD
+++ b/glsl/BUILD
@@ -14,7 +14,6 @@ toolchain_type(
 glsl_toolchain(
     name = "on_linux",
     glslc = "@vulkan_linux//:glslc",
-    is_windows = False,
 )
 
 toolchain(
@@ -33,7 +32,6 @@ toolchain(
 glsl_toolchain(
     name = "on_windows",
     glslc = "@vulkan_windows//:glslc",
-    is_windows = True,
 )
 
 toolchain(
@@ -53,7 +51,6 @@ toolchain(
 glsl_toolchain(
     name = "on_macos",
     glslc = "@vulkan_macos//:glslc",
-    is_windows = False,
 )
 
 toolchain(

--- a/glsl/rules.bzl
+++ b/glsl/rules.bzl
@@ -1,13 +1,15 @@
 """
 """
 
-GlslInfo = provider(fields=[
-    "includes",
-    "headers"
-])
+GlslInfo = provider(
+    "Provides header files and include paths for building GLSL targets",
+    fields = [
+        "includes",
+        "headers",
+    ],
+)
 
 def _glsl_header_library(ctx):
-
     strip_include_prefix = ctx.attr.strip_include_prefix
 
     includes = dict()
@@ -19,7 +21,6 @@ def _glsl_header_library(ctx):
 
     else:
         for hdr in ctx.files.hdrs:
-
             # check if the header is being included from the lluvia repo
             # or externally (e.g., mediapipe). For external inclusion, bazel
             # adds a "external/lluvia" path to all files of this repo, so I
@@ -32,34 +33,34 @@ def _glsl_header_library(ctx):
 
             else:
                 fail("strip_include_prefix \"{0}\" not found in header \"{1}\" path.".format(
-                    strip_include_prefix, hdr.path))
+                    strip_include_prefix,
+                    hdr.path,
+                ))
 
-    runfiles = ctx.runfiles(files=ctx.files.hdrs)
-    default_files = depset(direct=ctx.files.hdrs)
+    runfiles = ctx.runfiles(files = ctx.files.hdrs)
+    default_files = depset(direct = ctx.files.hdrs)
 
     return [
         GlslInfo(
-            headers=depset(direct=ctx.files.hdrs),
-            includes=depset(direct=includes.keys())
+            headers = depset(direct = ctx.files.hdrs),
+            includes = depset(direct = includes.keys()),
         ),
-        DefaultInfo(files=default_files, runfiles=runfiles)
+        DefaultInfo(files = default_files, runfiles = runfiles),
     ]
 
 def _glsl_shader(ctx):
-
     toolchain = ctx.toolchains["@rules_vulkan//glsl:toolchain_type"]
 
     shader = ctx.file.shader
 
     spirv_name = shader.basename + ".spv"
 
-    spirv = ctx.actions.declare_file(spirv_name, sibling=shader)
+    spirv = ctx.actions.declare_file(spirv_name, sibling = shader)
 
     args = ctx.actions.args()
     inputs = [shader]
 
     for dep in ctx.attr.deps:
-
         for inc in dep[GlslInfo].includes.to_list():
             args.add("-I", inc)
 
@@ -69,64 +70,43 @@ def _glsl_shader(ctx):
         for hdr in dep[GlslInfo].headers.to_list():
             inputs.append(hdr)
 
-
     args.add("-o", spirv)
     args.add(shader.path)
 
-    if toolchain.is_windows:
-        ctx.actions.run(
-            inputs = inputs,
-            outputs = [spirv],
-            arguments = [args],
-            executable = toolchain.glslc_executable,
-            progress_message = "compiling GLSL",
-            mnemonic = 'GLSLC'
-        )
-    else:
-        # ctx.actions.run(
-        #     inputs = inputs,
-        #     outputs = [spirv],
-        #     arguments = [args],
-        #     executable = toolchain.glslc_executable,
-        #     progress_message = "compiling GLSL",
-        #     mnemonic = 'GLSLC'
-        # )
-        # FIXME: using ctx.actions.run with toolchain.glslc_executable
-        #        does not work in Linux.
-        ctx.actions.run_shell(
-            inputs = inputs,
-            outputs = [spirv],
-            arguments = [args],
-            command = "{0} $@".format(toolchain.glslc_executable),
-            progress_message = "compiling GLSL",
-            mnemonic = 'GLSLC'
-        )
-
-    runfiles = ctx.runfiles(
-        files = [spirv]
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [spirv],
+        arguments = [args],
+        executable = toolchain.glslc_executable,
+        progress_message = "compiling GLSL",
+        mnemonic = "GLSLC",
     )
 
-    default_files = depset(direct=[spirv])
+    runfiles = ctx.runfiles(
+        files = [spirv],
+    )
+
+    default_files = depset(direct = [spirv])
 
     return [
-        DefaultInfo(files=default_files, runfiles=runfiles)
+        DefaultInfo(files = default_files, runfiles = runfiles),
     ]
 
 glsl_header_library = rule(
     implementation = _glsl_header_library,
     attrs = {
-        "hdrs": attr.label_list(allow_files=[".glsl"]),
-        "strip_include_prefix": attr.string(default=""),
+        "hdrs": attr.label_list(allow_files = [".glsl"]),
+        "strip_include_prefix": attr.string(default = ""),
     },
-    provides = [DefaultInfo, GlslInfo]
+    provides = [DefaultInfo, GlslInfo],
 )
 
 glsl_shader = rule(
     implementation = _glsl_shader,
     attrs = {
-        "shader": attr.label(allow_single_file=[".vert", ".frag", ".tesc", ".tese", ".geom", ".comp"]),
-        "deps": attr.label_list(providers=[GlslInfo]),
+        "shader": attr.label(allow_single_file = [".vert", ".frag", ".tesc", ".tese", ".geom", ".comp"]),
+        "deps": attr.label_list(providers = [GlslInfo]),
     },
     toolchains = ["@rules_vulkan//glsl:toolchain_type"],
-    provides = [DefaultInfo]
+    provides = [DefaultInfo],
 )

--- a/glsl/toolchain.bzl
+++ b/glsl/toolchain.bzl
@@ -2,35 +2,28 @@
 """
 
 def _glsl_toolchain_impl(ctx):
+    """
+    GLSL toolchain implementation
+    """
 
-    # it is expected the the glslc target contains one and only one
-    # file that is the compiler.
-    glslc_executable = ""
+    glslc_executable = ctx.executable.glslc
 
-    if ctx.attr.is_windows:
-        glslc_executable = ctx.attr.glslc.files.to_list()[0].path
-    else:
-        glslc_executable = "glslc"
-    
     toolchain_info = platform_common.ToolchainInfo(
         glslc = ctx.attr.glslc,
         glslc_executable = glslc_executable,
-        is_windows = ctx.attr.is_windows,
     )
 
     return [toolchain_info]
-
 
 glsl_toolchain = rule(
     implementation = _glsl_toolchain_impl,
     attrs = {
         "glslc": attr.label(
             doc = "The location of the glslc compiler.",
-            allow_single_file = True
+            executable = True,
+            cfg = "exec",
+            allow_single_file = True,
+            mandatory = True,
         ),
-        "is_windows": attr.bool(
-            doc = "Whether or not this toolchain runs in windows",
-            mandatory = True
-        )
     },
 )

--- a/vulkan/BUILD
+++ b/vulkan/BUILD
@@ -1,7 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 VULKAN_LINKOPTS = select({
-
     "@rules_vulkan//:linux": ["-lvulkan"],
     "@rules_vulkan//:android": [],
     "@rules_vulkan//:windows": [],
@@ -9,13 +8,15 @@ VULKAN_LINKOPTS = select({
     "//conditions:default": [],
 })
 
-VULKAN_LIBRARIES = select({
-    "@rules_vulkan//:windows": ["@vulkan_windows//:vulkan_cc_library"],
-    "@rules_vulkan//:darwin": ["@vulkan_macos//:vulkan_cc_library"],
-    "@rules_vulkan//:linux": ["@vulkan_linux//:vulkan_cc_library"],
-    "@rules_vulkan//:android": ["@vulkan_android//:vulkan_cc_library"],
-},
-no_match_error = "No configuration matches the supported platforms")
+VULKAN_LIBRARIES = select(
+    {
+        "@rules_vulkan//:windows": ["@vulkan_windows//:vulkan_cc_library"],
+        "@rules_vulkan//:darwin": ["@vulkan_macos//:vulkan_cc_library"],
+        "@rules_vulkan//:linux": ["@vulkan_linux//:vulkan_cc_library"],
+        "@rules_vulkan//:android": ["@vulkan_android//:vulkan_cc_library"],
+    },
+    no_match_error = "No configuration matches the supported platforms",
+)
 
 cc_library(
     name = "vulkan_cc_library",

--- a/vulkan/platform/android.bzl
+++ b/vulkan/platform/android.bzl
@@ -14,6 +14,12 @@ cc_library(
     linkstatic = False,
     visibility = ["//visibility:public"]
 )
+
+filegroup(
+    name = "glslc",
+    srcs = ["host_vulkan_sdk/bind/glslc"],
+    visibility = ["//visibility:public"],
+)
 """
 
 build_file_using_ndk = """
@@ -35,21 +41,29 @@ cc_library(
     ],
     visibility = ["//visibility:public"]
 )
+
+filegroup(
+    name = "glslc",
+    srcs = ["android_ndk/shader-tools/linux-x86_64/glslc"],
+    visibility = ["//visibility:public"],
+)
 """
 
 def _impl(repository_ctx):
+    """
+    Vulkan Android repository implementation
+    """
 
     use_host_vulkan_sdk = repository_ctx.attr.android_use_host_vulkan_sdk
 
     #################################################################
     # Configure the Vulkan SDK installed in the host machine
     if use_host_vulkan_sdk:
-        
         host_sdk_path = repository_ctx.attr.host_sdk_path
         if host_sdk_path == None:
             host_sdk_path = repository_ctx.os.environ.get("VULKAN_SDK", None)
 
-        if host_sdk_path == '' or host_sdk_path == None:
+        if host_sdk_path == "" or host_sdk_path == None:
             host_sdk_path = "/usr"
 
         repository_ctx.symlink(host_sdk_path, "host_vulkan_sdk")
@@ -60,22 +74,21 @@ def _impl(repository_ctx):
 
     #################################################################
     # Android NDK
-    ndk_home = repository_ctx.os.environ.get('ANDROID_NDK_HOME', None)
+    ndk_home = repository_ctx.os.environ.get("ANDROID_NDK_HOME", None)
     if ndk_home == None:
-        fail('ANDROID_NDK_HOME environment variable not found')
+        fail("ANDROID_NDK_HOME environment variable not found")
 
     repository_ctx.symlink(ndk_home, "android_ndk")
 
-    file_content = ''
+    file_content = ""
     if use_host_vulkan_sdk:
         file_content = build_file_using_host_sdk
 
-    # otherwise, use the Android NDK sources
+        # otherwise, use the Android NDK sources
     else:
-        file_content = build_file_using_ndk 
+        file_content = build_file_using_ndk
 
     repository_ctx.file("BUILD.bazel", file_content)
-
 
 vulkan_android = repository_rule(
     implementation = _impl,
@@ -83,12 +96,14 @@ vulkan_android = repository_rule(
     environ = ["ANDROID_NDK_HOME", "VULKAN_SDK"],
     attrs = {
         "host_sdk_path": attr.string(
-            default = '',
+            default = "",
             mandatory = False,
-            doc = 'Path to the host Vulkan SDK'),
+            doc = "Path to the host Vulkan SDK",
+        ),
         "android_use_host_vulkan_sdk": attr.bool(
             default = False,
             mandatory = False,
-            doc = 'If True, use the host Vulkan SDK headers, otherwise use those provided by the NDK.',)
+            doc = "If True, use the host Vulkan SDK headers, otherwise use those provided by the NDK.",
+        ),
     },
 )

--- a/vulkan/platform/linux.bzl
+++ b/vulkan/platform/linux.bzl
@@ -2,14 +2,19 @@
 """
 
 def _impl(repository_ctx):
+    """
+    Vulkan linux repository implementation
+    """
 
     sdk_path = repository_ctx.attr.path
+    lib_path = "lib"
 
-    if sdk_path == '':
+    if sdk_path == "":
         sdk_path = repository_ctx.os.environ.get("VULKAN_SDK", None)
 
-    if sdk_path == '' or sdk_path == None:
+    if sdk_path == "" or sdk_path == None:
         sdk_path = "/usr"
+        lib_path = "lib/x86_64-linux-gnu"
 
     repository_ctx.symlink(sdk_path, "vulkan_sdk_linux")
 
@@ -21,7 +26,7 @@ def _impl(repository_ctx):
 
 cc_library(
     name = "vulkan_cc_library",
-    srcs = ["vulkan_sdk_linux/lib/x86_64-linux-gnu/libvulkan.so"],
+    srcs = ["vulkan_sdk_linux/{0}/libvulkan.so"],  # replace lib_path
     hdrs = glob([
         "vulkan_sdk_linux/include/vulkan/**/*.h",
         "vulkan_sdk_linux/include/vulkan/**/*.hpp",
@@ -29,14 +34,12 @@ cc_library(
     visibility = ["//visibility:public"]
 )
 
-# FIXME: I cannot actually run this one in _glsl_shader. There is an error
-# when running _glsl_shader rule
 filegroup(
     name = "glslc",
     srcs = ["vulkan_sdk_linux/bin/glslc"],
     visibility = ["//visibility:public"],
 )
-""".format(str(glslc_path)[1:])
+""".format(lib_path)
 
     repository_ctx.file("BUILD.bazel", file_content)
 

--- a/vulkan/platform/macos.bzl
+++ b/vulkan/platform/macos.bzl
@@ -2,27 +2,24 @@
 """
 
 def _impl(repository_ctx):
-
     sdk_path = repository_ctx.attr.path
 
-    if sdk_path == '':
+    if sdk_path == "":
         sdk_path = repository_ctx.os.environ.get("VULKAN_SDK", None)
 
-    if sdk_path == '' or sdk_path == None:
+    if sdk_path == "" or sdk_path == None:
         fail("Unable to find Vulkan SDK")
 
     repository_ctx.symlink(sdk_path, "vulkan_sdk_macos")
-
-    glslc_path = repository_ctx.which("glslc")
-    if glslc_path == None:
-        fail("Unable to find glslc binary in the system")
 
     file_content = """
 
 cc_library(
     name = "vulkan_cc_library",
     # using libvulkan.1.dylib and libvulkan.1.x.xxx.dylib from sdk
-    srcs = glob(["vulkan_sdk_macos/lib/libvulkan.1*.dylib"]),
+    srcs = glob([
+        "vulkan_sdk_macos/lib/libvulkan.1*.dylib"
+    ]),
     hdrs = glob([
         "vulkan_sdk_macos/include/vulkan/**/*.h",
         "vulkan_sdk_macos/include/vulkan/**/*.hpp",
@@ -36,7 +33,7 @@ filegroup(
     srcs = ["vulkan_sdk_macos/bin/glslc"],
     visibility = ["//visibility:public"],
 )
-""".format(str(glslc_path)[1:])
+"""
 
     repository_ctx.file("BUILD.bazel", file_content)
 


### PR DESCRIPTION
Fix how the GLSLC compiler is made available through the repository rules and how it is used by the GLSL rules.

* On Android, the `use_host_vulkan_sdk` attribute also selects whether the `glslc` compiler shipped with the NDK is used or not.